### PR TITLE
Cooking timer: Match max time to device

### DIFF
--- a/custom_components/anova_nano/number.py
+++ b/custom_components/anova_nano/number.py
@@ -34,6 +34,8 @@ ENTITY_DESCRIPTIONS = [
         translation_key="cooking_time",
         native_unit_of_measurement=UnitOfTime.MINUTES,
         device_class=NumberDeviceClass.DURATION,
+        # Max time settable on device: 99h:55m
+        native_max_value=99 * 60 + 55,
         set_fn="set_timer",
         state_attr="timer",
     ),


### PR DESCRIPTION
Currently the cooking timer is limited to 100 minutes in the UI and hass will refuse to set a higher value. This is a bit limiting for many sous vide recipes.

I don't know which value makes sense but 99h 55m is the most I can set on my Nano.